### PR TITLE
Refactor conftest.py for better parametrizations

### DIFF
--- a/pyflagser/tests/conftest.py
+++ b/pyflagser/tests/conftest.py
@@ -2,46 +2,64 @@ import os
 from tempfile import mkdtemp
 from urllib.request import urlopen, urlretrieve
 
+from flagser_pybind import implemented_filtrations
+
+files_with_filtration_results = ["d5.flag"]
+
 
 def pytest_addoption(parser):
-    parser.addoption('--webdl', action='store_true', default=False,
-                     help='Whether or not to download files '
-                          'required for testing from the web')
+    parser.addoption("--webdl", action="store_true", default=False,
+                     help="Whether or not to download files "
+                          "required for testing from the web")
+
+
+class FlagFiles:
+    paths = None
 
 
 def fetch_flag_files(webdl):
     if not webdl:
-        dirname = os.path.join(os.path.dirname(__file__), '../../flagser/test')
+        dirname = os.path.join(os.path.dirname(__file__), "../../flagser/test")
         try:
             fnames = os.listdir(dirname)
             flag_files = [os.path.join(dirname, fname) for fname in fnames
                           if fname.endswith(".flag")]
+            return flag_files
         except FileNotFoundError:
-            print(f'.flag files looked for in {dirname}, but directory does '
-                  'not exist. Pass the optional argument --webdl to '
-                  'automatically download these files into a temporary '
-                  'folder and run tests.')
+            print(f".flag files looked for in {dirname}, but directory does "
+                  "not exist. Pass the optional argument --webdl to "
+                  "automatically download these files into a temporary "
+                  "folder and run tests.")
     else:
         # Download from remote bucket
         temp_dir = mkdtemp()
-        bucket_url = 'https://storage.googleapis.com/l2f-open-models/' \
-                     'giotto-tda/flagser/test/'
-        flag_files_list = bucket_url + 'flag_files_list.txt'
+        bucket_url = "https://storage.googleapis.com/l2f-open-models/" \
+                     "giotto-tda/flagser/test/"
+        flag_files_list = bucket_url + "flag_files_list.txt"
         with urlopen(flag_files_list) as f:
-            flag_file_names = f.read().decode('utf8').splitlines()
+            flag_file_names = f.read().decode("utf8").splitlines()
             flag_files = []
             for fname in flag_file_names:
                 url = bucket_url + fname
                 fpath = os.path.join(temp_dir, fname)
                 urlretrieve(url, fpath)
                 flag_files.append(fpath)
-    return flag_files
+        return flag_files
 
 
 def pytest_generate_tests(metafunc):
     # This is called for every test. Only get/set command line arguments
     # if the argument is specified in the list of test "fixturenames".
-    webdl = metafunc.config.option.webdl
-    if 'flag_file' in metafunc.fixturenames:
-        flag_files = fetch_flag_files(webdl)
-        metafunc.parametrize('flag_file', flag_files)
+    if FlagFiles.paths is None:
+        webdl = metafunc.config.option.webdl
+        FlagFiles.paths = fetch_flag_files(webdl)
+    if "filtration" in metafunc.fixturenames:
+        metafunc.parametrize("filtration", implemented_filtrations)
+        paths = [
+            path for path in FlagFiles.paths
+            if os.path.split(path)[1] in files_with_filtration_results
+        ]
+    else:
+        paths = FlagFiles.paths
+    if "flag_file" in metafunc.fixturenames:
+        metafunc.parametrize("flag_file", paths)

--- a/pyflagser/tests/test_flagser.py
+++ b/pyflagser/tests/test_flagser.py
@@ -6,7 +6,6 @@ import numpy as np
 from numpy.testing import assert_almost_equal
 
 from pyflagser import loadflag, flagser
-from flagser_pybind import implemented_filtrations
 
 betti = {
     'a.flag': [1, 2, 0],
@@ -28,9 +27,7 @@ betti = {
     'd10.flag': [1, 0, 0, 0, 0, 0, 0, 0, 0, 1334961],
 }
 
-"""
-Filtrations are only tested for d5.flag
-"""
+# Filtrations are only tested for d5.flag, see conftest.py
 filtrations_results = {
     'dimension':
     {
@@ -169,14 +166,7 @@ filtrations_results = {
 }
 
 
-def test_flagser(flag_file):
-    betti_exp = betti[os.path.split(flag_file)[1]]
-    flag_matrix = loadflag(flag_file)
-    betti_res = flagser(flag_matrix)['betti']
-    assert_almost_equal(betti_res, betti_exp)
-
-
-def are_matrix_equal(m1, m2):
+def are_matrices_equal(m1, m2):
     for i in range(min(len(m1), len(m2))):
         m1f = np.array(m1[i]).flatten()
         m2f = np.array(m2[i]).flatten()
@@ -185,20 +175,23 @@ def are_matrix_equal(m1, m2):
     return True
 
 
-def test_filtrations(flag_file):
-    """
-    Testing all filtrations available for dataset d5.flag
-    """
-    if os.path.split(flag_file)[1] == 'd5.flag':
-        flag_matrix = loadflag(flag_file)
-        for filtration in implemented_filtrations:
-            print('testing {} filtration'.format(filtration))
-            res = flagser(flag_matrix, max_dimension=1, directed=False,
-                          filtration=filtration)
-            for filt, tests in filtrations_results.items():
-                if filtration == filt:
-                    tmp = np.array(res['dgms']).tolist()
-                    tmp2 = np.array(tests['dgms']).tolist()
-                    assert are_matrix_equal(tmp, tmp2), \
-                        "diagrams {} \n and {} \n are not equal"\
-                        .format(tmp, tmp2)
+def test_betti(flag_file):
+    betti_exp = betti[os.path.split(flag_file)[1]]
+    flag_matrix = loadflag(flag_file)
+    betti_res = flagser(flag_matrix)["betti"]
+    assert_almost_equal(betti_res, betti_exp)
+
+
+def test_filtrations_d5(flag_file, filtration):
+    """Testing all filtrations available for dataset d5.flag,
+    see conftest.py"""
+    flag_matrix = loadflag(flag_file)
+    res = flagser(flag_matrix, max_dimension=1, directed=False,
+                  filtration=filtration)
+    for filt, tests in filtrations_results.items():
+        if filtration == filt:
+            tmp = np.array(res["dgms"]).tolist()
+            tmp2 = np.array(tests["dgms"]).tolist()
+            assert are_matrices_equal(tmp, tmp2), \
+                "Diagrams {} \n and {} \n are not equal"\
+                .format(tmp, tmp2)


### PR DESCRIPTION
The new fixture `filtration` is introduced alongside `flag_file` for all tests. If it is present then `flag_file` has to be in `files_with_filtration_results` which is currently set to`["d5.flag"]`. This way we avoid skipping tests but can parametrize wrt the filtration in the case of d5.flag.
